### PR TITLE
Create bower.json for prod

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "elementQuery-prod",
+  "main": "elementQuery.js",
+  "homepage": "https://github.com/tysonmatanich/elementQuery",
+  "description": "An element query polyfill you can use today.",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "external"
+  ]
+}


### PR DESCRIPTION
And another one for the prod branch

alas, there is no way to register a package with bower and point it at a branch. but users can still do this:

``` ruby
asset "elementQuery", github: "tysonmatanich/elementQuery#prod"
```

or this

``` javascript
{
  "dependencies": {
    "elementQuery": "git://github.com/tysonmatanich/elementQuery#prod"
  }
}
```
